### PR TITLE
Enhance UX with 12‑hour inputs and bigger UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,25 +13,31 @@
 <h1>World Time Converter</h1>
 <div class="converter" id="lk-to-us">
 <h2>Sri Lanka → Atlanta</h2>
-<div class="input-group">
-<label for="lk-hours">Hours</label>
-<input type="number" id="lk-hours" min="0" max="23" placeholder="HH">
-<label for="lk-minutes">Minutes</label>
-<input type="number" id="lk-minutes" min="0" max="59" placeholder="MM">
-<button id="convert-lk">Convert</button>
-</div>
-<p class="result" id="us-result"></p>
+        <div class="input-group">
+            <input type="number" id="lk-hours" min="1" max="12" placeholder="HH">
+            <span class="colon">:</span>
+            <input type="number" id="lk-minutes" min="0" max="59" placeholder="MM">
+            <select id="lk-ampm">
+                <option value="AM">AM</option>
+                <option value="PM">PM</option>
+            </select>
+        </div>
+        <button id="convert-lk">Convert</button>
+        <p class="result" id="us-result">Converted time will appear here</p>
 </div>
 <div class="converter" id="us-to-lk">
 <h2>Atlanta → Sri Lanka</h2>
 <div class="input-group">
-<label for="us-hours">Hours</label>
-<input type="number" id="us-hours" min="0" max="23" placeholder="HH">
-<label for="us-minutes">Minutes</label>
-<input type="number" id="us-minutes" min="0" max="59" placeholder="MM">
-<button id="convert-us">Convert</button>
+    <input type="number" id="us-hours" min="1" max="12" placeholder="HH">
+    <span class="colon">:</span>
+    <input type="number" id="us-minutes" min="0" max="59" placeholder="MM">
+    <select id="us-ampm">
+        <option value="AM">AM</option>
+        <option value="PM">PM</option>
+    </select>
 </div>
-<p class="result" id="lk-result"></p>
+<button id="convert-us">Convert</button>
+<p class="result" id="lk-result">Converted time will appear here</p>
 </div>
 </div>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,25 +1,29 @@
 const { DateTime } = luxon;
 
-function convertTime(fromZone, toZone, hours, minutes) {
+function convertTime(fromZone, toZone, hour12, minutes, ampm) {
+  let hrs = parseInt(hour12, 10);
+  if (ampm === 'PM' && hrs !== 12) hrs += 12;
+  if (ampm === 'AM' && hrs === 12) hrs = 0;
   const now = DateTime.now().setZone(fromZone);
-  const dt = now.set({ hour: hours, minute: minutes, second: 0, millisecond: 0 });
-  const converted = dt.setZone(toZone);
-  return converted.toFormat('HH:mm');
+  const dt = now.set({ hour: hrs, minute: parseInt(minutes, 10), second: 0, millisecond: 0 });
+  return dt.setZone(toZone);
 }
 
-function setupConverter(buttonId, hourId, minuteId, resultId, fromZone, toZone) {
+function setupConverter(buttonId, hourId, minuteId, ampmId, resultId, fromZone, toZone, toLabel) {
   const button = document.getElementById(buttonId);
   button.addEventListener('click', () => {
-    const hours = parseInt(document.getElementById(hourId).value, 10);
-    const minutes = parseInt(document.getElementById(minuteId).value, 10);
-    if (isNaN(hours) || isNaN(minutes)) {
+    const hours = document.getElementById(hourId).value;
+    const minutes = document.getElementById(minuteId).value;
+    const ampm = document.getElementById(ampmId).value;
+    if (hours === '' || minutes === '') {
       document.getElementById(resultId).textContent = 'Please enter valid time.';
       return;
     }
-    const formatted = convertTime(fromZone, toZone, hours, minutes);
-    document.getElementById(resultId).textContent = formatted;
+    const converted = convertTime(fromZone, toZone, hours, minutes, ampm);
+    const formatted = converted.toFormat('h:mm a');
+    document.getElementById(resultId).textContent = `Converted Time: ${formatted} (${toLabel})`;
   });
 }
 
-setupConverter('convert-lk', 'lk-hours', 'lk-minutes', 'us-result', 'Asia/Colombo', 'America/New_York');
-setupConverter('convert-us', 'us-hours', 'us-minutes', 'lk-result', 'America/New_York', 'Asia/Colombo');
+setupConverter('convert-lk', 'lk-hours', 'lk-minutes', 'lk-ampm', 'us-result', 'Asia/Colombo', 'America/New_York', 'Atlanta Time');
+setupConverter('convert-us', 'us-hours', 'us-minutes', 'us-ampm', 'lk-result', 'America/New_York', 'Asia/Colombo', 'Sri Lanka Time');

--- a/style.css
+++ b/style.css
@@ -27,10 +27,11 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+  font-size: 1.2rem;
 }
 
 .container {
-  padding: 2rem;
+  padding: 2.5rem;
   background: var(--glass-bg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
@@ -62,16 +63,18 @@ h1 {
   margin-bottom: 1rem;
 }
 
-input {
-  padding: 0.5rem 1rem;
+input,
+select {
+  padding: 0.75rem 1.25rem;
   border: none;
   border-radius: 10px;
   box-shadow: inset 2px 2px 5px var(--shadow-dark),
               inset -2px -2px 5px var(--shadow-light);
   background: var(--foreground);
   color: var(--text-color);
-  width: 4rem;
+  width: 5rem;
   text-align: center;
+  font-size: 1rem;
   transition: box-shadow 0.3s;
 }
 
@@ -82,7 +85,7 @@ input:focus {
 }
 
 button {
-  padding: 0.5rem 1rem;
+  padding: 0.75rem 1.5rem;
   border: none;
   border-radius: 10px;
   background: var(--foreground);
@@ -91,6 +94,7 @@ button {
               -4px -4px 8px var(--shadow-light);
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.3s;
+  font-size: 1rem;
 }
 
 button:hover {
@@ -106,14 +110,22 @@ button:active {
 .result {
   min-height: 1.5rem;
   font-weight: bold;
+  color: var(--text-color);
+}
+
+.colon {
+  display: flex;
+  align-items: center;
+  font-size: 1.2rem;
 }
 
 @media (max-width: 480px) {
   .container {
-    padding: 1rem;
+    padding: 1.5rem;
   }
 
-  input {
-    width: 3rem;
+  input,
+  select {
+    width: 4rem;
   }
 }


### PR DESCRIPTION
## Summary
- allow 12-hour clock inputs with AM/PM dropdowns
- show converted time with AM/PM and zone label
- enlarge fonts, inputs and buttons for better mobile use
- add placeholder text in result area

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686d7a58a114832d9a7270ff7493200b