### PR TITLE
Improve pastel UI design

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>World Time Converter</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&family=Racing+Sans+One&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">
 <script src="https://cdn.jsdelivr.net/npm/luxon@3/build/global/luxon.min.js" defer></script>
 <script src="script.js" defer></script>

--- a/style.css
+++ b/style.css
@@ -1,25 +1,15 @@
 :root {
-  --background: #e0e0e0;
-  --foreground: #f0f0f3;
+  --background: #F5EFFF;
+  --foreground: #E5D9F2;
   --shadow-light: rgba(255, 255, 255, 0.7);
-  --shadow-dark: rgba(0, 0, 0, 0.15);
-  --glass-bg: rgba(255, 255, 255, 0.3);
+  --shadow-dark: rgba(0, 0, 0, 0.1);
+  --glass-bg: rgba(229, 217, 242, 0.5);
   --text-color: #333;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #1e1e1e;
-    --foreground: #2b2b2b;
-    --shadow-light: rgba(255, 255, 255, 0.1);
-    --shadow-dark: rgba(0, 0, 0, 0.5);
-    --glass-bg: rgba(40, 40, 40, 0.4);
-    --text-color: #f0f0f0;
-  }
+  --accent: #A594F9;
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Open Sans', sans-serif;
   background: var(--background);
   color: var(--text-color);
   height: 100vh;
@@ -32,18 +22,19 @@ body {
 
 .container {
   padding: 2.5rem;
-  background: var(--glass-bg);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
+  background: var(--foreground);
   border-radius: 20px;
-  box-shadow: 8px 8px 16px var(--shadow-dark),
-              -8px -8px 16px var(--shadow-light);
+  box-shadow: 4px 4px 12px var(--shadow-dark),
+              -4px -4px 12px var(--shadow-light);
   width: 90%;
   max-width: 500px;
   text-align: center;
 }
 
-h1 {
+h1,
+h2 {
+  font-family: 'Racing Sans One', cursive;
+  color: var(--accent);
   margin-bottom: 1.5rem;
 }
 
@@ -51,8 +42,9 @@ h1 {
   margin-bottom: 2rem;
   padding: 1rem;
   border-radius: 15px;
-  box-shadow: inset 5px 5px 10px var(--shadow-dark),
-              inset -5px -5px 10px var(--shadow-light);
+  background: var(--background);
+  box-shadow: inset 4px 4px 8px var(--shadow-dark),
+              inset -4px -4px 8px var(--shadow-light);
 }
 
 .input-group {
@@ -70,12 +62,17 @@ select {
   border-radius: 10px;
   box-shadow: inset 2px 2px 5px var(--shadow-dark),
               inset -2px -2px 5px var(--shadow-light);
-  background: var(--foreground);
+  background: #fff;
   color: var(--text-color);
   width: 5rem;
   text-align: center;
   font-size: 1rem;
   transition: box-shadow 0.3s;
+}
+
+#lk-ampm,
+#us-ampm {
+  width: 6rem;
 }
 
 input:focus {
@@ -110,7 +107,7 @@ button:active {
 .result {
   min-height: 1.5rem;
   font-weight: bold;
-  color: var(--text-color);
+  color: var(--accent);
 }
 
 .colon {
@@ -127,5 +124,10 @@ button:active {
   input,
   select {
     width: 4rem;
+  }
+
+  #lk-ampm,
+  #us-ampm {
+    width: 5rem;
   }
 }


### PR DESCRIPTION
## Summary
- add Google Fonts for new typography
- refresh palette with soft purples
- give headings a friendly Racing Sans One typeface
- lighten component backgrounds and inputs
- widen AM/PM dropdown to avoid clipping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d7ce12c10832db7aa74be26ef4e84