### PR TITLE
Improve layout spacing and responsiveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-#time
+# World Time Converter
+
+Simple dashboard showing live times for two cities and a converter tool.
+
+Open `index.html` in your browser to use the app.

--- a/index.html
+++ b/index.html
@@ -37,16 +37,18 @@
     <section class="converter-tool">
       <h2>Time Converter</h2>
       <div class="converter-fields">
-        <select id="from-city" class="city-select"></select>
-        <input type="number" id="from-hours" min="1" max="12" placeholder="HH">
-        <span class="colon">:</span>
-        <input type="number" id="from-minutes" min="0" max="59" placeholder="MM">
-        <select id="from-ampm" class="ampm-select">
-          <option value="AM">AM</option>
-          <option value="PM">PM</option>
-        </select>
-        <span class="arrow">&#8594;</span>
-        <select id="to-city" class="city-select"></select>
+        <div class="input-row">
+          <select id="from-city" class="city-select"></select>
+          <input type="number" id="from-hours" min="1" max="12" placeholder="HH">
+          <span class="colon">:</span>
+          <input type="number" id="from-minutes" min="0" max="59" placeholder="MM">
+          <select id="from-ampm" class="ampm-select">
+            <option value="AM">AM</option>
+            <option value="PM">PM</option>
+          </select>
+          <span class="arrow">&#8594;</span>
+          <select id="to-city" class="city-select"></select>
+        </div>
         <button id="convert-btn" type="button">Convert</button>
       </div>
       <div class="result" id="convert-result"></div>

--- a/style.css
+++ b/style.css
@@ -24,12 +24,15 @@ body {
   justify-content: center;
   gap: 2rem;
   padding: 2rem 5%;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
   border-bottom: 1px solid var(--divider);
 }
 
 .time-panel {
   flex: 1 1 200px;
   text-align: center;
+  margin-bottom: 1rem;
 }
 
 .city-select {
@@ -40,7 +43,7 @@ body {
   border-radius: 4px;
   font-family: inherit;
   font-size: 1rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 1rem;
 }
 
 .time {
@@ -79,15 +82,24 @@ body {
 
 main {
   padding: 2rem 5%;
+  padding-bottom: 3rem;
 }
 
 .converter-tool h2 {
   margin: 0 0 1rem;
   font-size: 1.75rem;
   font-weight: 600;
+  text-align: center;
 }
 
 .converter-fields {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.input-row {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -126,6 +138,12 @@ button {
   cursor: pointer;
 }
 
+#convert-btn {
+  margin-top: 0.5rem;
+  width: 150px;
+  align-self: center;
+}
+
 button:hover {
   background: var(--accent-hover);
 }
@@ -139,6 +157,19 @@ button:hover {
 }
 
 @media (max-width: 480px) {
+  .dashboard {
+    flex-direction: column;
+  }
+
+  .input-row {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  #convert-btn {
+    width: 100%;
+  }
+
   .hm {
     font-size: 2.2rem;
   }


### PR DESCRIPTION
## Summary
- tweak page layout margins for header and time panels
- center "Time Converter" header text
- reposition converter inputs with a new row wrapper
- center the Convert button and add spacing
- add responsive styles for mobile screens
- update README with brief usage notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d839b9674832d8ee4cc0542d2dd95